### PR TITLE
Fix call to constructor of ChartOptions

### DIFF
--- a/GoogleCharts/Options/ChartOptions.php
+++ b/GoogleCharts/Options/ChartOptions.php
@@ -12,4 +12,11 @@ class ChartOptions implements ChartOptionsInterface
     use HeightTrait;
 
     use WidthTrait;
+    
+    /**
+     * ChartOptions constructor.
+     */
+    public function __construct()
+    { 
+    }
 }


### PR DESCRIPTION
[2018-01-12 13:32:47] request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Cannot call constructor" at mypath/vendor/cmen/google-charts-bundle/GoogleCharts/Options/GaugeChart/GaugeChartOptions.php line 107 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Cannot call constructor at mypath/vendor/cmen/google-charts-bundle/GoogleCharts/Options/GaugeChart/GaugeChartOptions.php:107)"} []

So we need to add a constructor to avoid this issue.

Reproducible -> 

    $currentQuarterGauge = new GaugeChart();
    $currentQuarterGauge->getData()->setArrayToDataTable(
      [
        ['Label', 'Value'],
        ['Quarter Target', (int)$report['totalSumOfDeals']['current']['total']],
      ]
    );
    $currentQuarterGauge->getOptions()->setWidth(200);
    $currentQuarterGauge->getOptions()->setHeight(200);
    $currentQuarterGauge->getOptions()->setGreenFrom(($quarterTarget/5)*4);
    $currentQuarterGauge->getOptions()->setGreenTo($quarterTarget);
    $currentQuarterGauge->getOptions()->setRedFrom($quarterTarget);
    $currentQuarterGauge->getOptions()->setRedTo(($quarterTarget/5)*6);
    $currentQuarterGauge->getOptions()->setMinorTicks(10);
    $currentQuarterGauge->getOptions()->setMax(($quarterTarget/5)*6);