### PR TITLE
add return type to getFunctions()

### DIFF
--- a/Twig/GoogleChartsExtension.php
+++ b/Twig/GoogleChartsExtension.php
@@ -20,7 +20,7 @@ class GoogleChartsExtension extends AbstractExtension
         $this->chartOutput = $chartOutput;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('gc_draw', [$this, 'gcDraw'], ['is_safe' => ['html']]),


### PR DESCRIPTION
This gets rid of the deprecation warning:

Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "CMEN\GoogleChartsBundle\Twig\GoogleChartsExtension" now to avoid errors or add an explicit @return annotation to suppress this message.